### PR TITLE
Add support for authors (outside of data)

### DIFF
--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -1,5 +1,9 @@
 {% assign author = page.author | default: page.authors[0] | default: site.author %}
+{% if site.authors|where:"title",author|first %}
+{% assign author = site.authors|where:"title",author|first %}
+{% else %}
 {% assign author = site.data.authors[author] | default: author %}
+{% endif %}
 
 <div itemscope itemtype="http://schema.org/Person">
 


### PR DESCRIPTION
Allow the creation of a new category: the authors.

The change patches the base theme to allow the usage of the author
sidebar which comes from minimal-mistakes.
That sidebar already supports authors added through the data files,
but this new authors type will be managed through separate files
instead (thanks to Netlify CMS).